### PR TITLE
fix bugs in runslip.py and forward.py

### DIFF
--- a/src/python/mudpy/forward.py
+++ b/src/python/mudpy/forward.py
@@ -661,7 +661,7 @@ def load_fakequakes_synthetics(home,project_name,fault_name,model_name,GF_list,G
             for kfault in range(Nfaults):
                 #Get subfault GF directory
                 nsub='sub'+str(int(source[kfault,0])).rjust(4,'0')
-                nfault='subfault'+str(int(source[kfault,0])).U(4,'0')
+                nfault='subfault'+str(int(source[kfault,0])).rjust(4,'0')
                 strdepth='%.4f' % source[kfault,3]
                 syn_path=home+project_name+'/GFs/dynamic/'+model_name+'_'+strdepth+'.'+nsub+'/'
                 #Get synthetics

--- a/src/python/mudpy/runslip.py
+++ b/src/python/mudpy/runslip.py
@@ -226,7 +226,7 @@ def make_parallel_green(home,project_name,station_file,fault_name,model_name,dt,
     for k in range(ncpus):
         i=arange(k+hot_start,len(source),ncpus)
         mpi_source=source[i,:]
-        fmt='%d\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f'
+        fmt='%d\t%10.6f\t%10.6f\t%.8f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f'
         savetxt(home+project_name+'/data/model_info/mpi_source.'+str(k)+'.fault',mpi_source,fmt=fmt)
     #Make mpi system call
     print("MPI: Starting GFs computation on", ncpus, "CPUs\n")
@@ -331,7 +331,7 @@ def make_parallel_synthetics(home,project_name,station_file,fault_name,model_nam
     for k in range(ncpus):
         i=arange(k+hot_start,len(source),ncpus)
         mpi_source=source[i,:]
-        fmt='%d\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f'
+        fmt='%d\t%10.6f\t%10.6f\t%.8f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f\t%10.6f'
         savetxt(home+project_name+'/data/model_info/mpi_source.'+str(k)+'.fault',mpi_source,fmt=fmt)
     #Make mpi system call
     print("MPI: Starting synthetics computation on", ncpus, "CPUs\n")


### PR DESCRIPTION
In forward.py Line:664
   the .U(4,'0') -> .rjust(4,'0')

In runslip.py Line:229&334
   The original float precision (%10.6f) is not enough for the fault file that I'm using (e.g. %.8f). Thus, when mpi writes the fault file to many mpi_faults. It will create a slightly different directory name -> sub9999 v.s. sub9998 and bug the further calculations.
   Fixed the depth precision from %10.6 -> %.8f