### PR TITLE
Update nepal_version2.inv.py

### DIFF
--- a/examples/nepal_inverse/nepal_version2.inv.py
+++ b/examples/nepal_inverse/nepal_version2.inv.py
@@ -60,7 +60,7 @@ bounds=(top,bottom,left,right)
 ################################################################################e=
 
 ########      Run-time modifications to the time series             ############
-weight=None
+weight=True
 decimate=None  #Decimate by constant (=None for NO decimation)
 # #Corner frequencies in Hz =None if no filter is desired
  # [0.5] is a low pass filter


### PR DESCRIPTION
The nepal_version2.inv.py does not properly run the inversion step if the weight = False. However, when I change weight = True it runs properly. The code is finding the weighted Green's function which is expressed as WG in the code. If the weight = False, WG is not generated. Hence, the software fails to produce the slip inversion.