### PR TITLE
modify waveforms_fakequakes to handle len(all_sources)=1

### DIFF
--- a/src/python/mudpy/forward.py
+++ b/src/python/mudpy/forward.py
@@ -298,6 +298,8 @@ def waveforms_fakequakes(home,project_name,fault_name,rupture_list,GF_list,
         all_sources=array([rupture_name])  
     else:
         all_sources=genfromtxt(home+project_name+'/data/'+rupture_list,dtype='U')
+        all_sources = array(all_sources, ndmin=1)  # in case only 1 entry
+
     
     #Load all synthetics
     print('... loading all synthetics into memory')


### PR DESCRIPTION
Turn `all_sources` into a list if it isn't already.

@dmelgarm: another question about this `forward.py` file:   As of d65542d98, it now starts with
```
from numba import jit
```
but `jit` is not used.  I would suggest removing this line if it's not going to be used to remove the `numba` dependency, since it doesn't seem to be used anywhere else.