### PR TITLE
Create send_update_signal.yml

### DIFF
--- a/.github/workflows/send_update_signal.yml
+++ b/.github/workflows/send_update_signal.yml
@@ -9,8 +9,6 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest    
     steps:
-    
-	# Send a signal to on_demand_fakequakes repo that MudPys been updated
       - name: Send repository dispatch event
         run: |
           curl -L \

--- a/.github/workflows/send_update_signal.yml
+++ b/.github/workflows/send_update_signal.yml
@@ -1,0 +1,22 @@
+name: Dispatch Event on Master Update
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest    
+    steps:
+    
+	# Send a signal to on_demand_fakequakes repo that MudPys been updated
+      - name: Send repository dispatch event
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.CICD_PAT }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/UO-Geophysics/on_demand_fakequakes/dispatches \
+          -d '{"event_type":"repo-update","client_payload":{"unit":false,"integration":true}}'


### PR DESCRIPTION
Creates a GitHub Action that sends a signal to on_demand_fakequakes that MudPy has been updated on the master, triggering on_demand_fakequakes to get the new MudPy and build a new Docker image for the workflow 